### PR TITLE
Use POSIX compliant string equality operator

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,24 +51,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [ "$(uname)" == "Darwin" ]
+if [ "$(uname)" = "Darwin" ]
 then
     # for Mac OSX
     export KERAS_BACKEND=tensorflow
-elif [ "$(uname)" == "Linux" ]
+elif [ "$(uname)" = "Linux" ]
 then
     # for Linux
     export KERAS_BACKEND=theano

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
     build:


### PR DESCRIPTION
In some systems, Keras activation script fails due to string equality check. I refactored to check it via single equality sign, a.k.a. standard for POSIX compliant shells.

Example:

![image](https://image.ibb.co/c58inR/Screen_Shot_2018_01_14_at_13_06_19.png)

Info:

https://unix.stackexchange.com/a/208097
https://stackoverflow.com/a/1089833