### PR TITLE
Remove theano as a dependency for keras

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,13 +1,3 @@
-:: Figure out the default Keras backend by reading the config file.
-python %CONDA_PREFIX%\etc\keras\load_config.py > temp.txt
-set /p KERAS_BACKEND=<temp.txt
-del temp.txt
+set /p KERAS_BACKEND=tensorflow
 
-:: Try to use the default Keras backend.
-:: Fallback to Theano if it fails (Theano always works).
 python -c "import keras" 1> nul 2>&1
-if errorlevel 1 (
-    ver > nul
-    set "KERAS_BACKEND=tensorflow"
-    python -c "import keras" 1> nul 2>&1
-)

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -8,6 +8,6 @@ del temp.txt
 python -c "import keras" 1> nul 2>&1
 if errorlevel 1 (
     ver > nul
-    set "KERAS_BACKEND=theano"
+    set "KERAS_BACKEND=tensorflow"
     python -c "import keras" 1> nul 2>&1
 )

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -7,6 +7,6 @@ KERAS_BACKEND="$(python ${CONDA_PREFIX}/etc/keras/load_config.py)"
 # Fallback to Theano if it fails (Theano always works).
 python -c "import keras" &>/dev/null || {
     test "true";
-    export KERAS_BACKEND="theano"
+    export KERAS_BACKEND="tensorflow"
     python -c "import keras" &>/dev/null
 }

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,12 +1,3 @@
 #!/bin/bash
 
-# Figure out the default Keras backend by reading the config file.
-KERAS_BACKEND="$(python ${CONDA_PREFIX}/etc/keras/load_config.py)"
-
-# Try to use the default Keras backend.
-# Fallback to Theano if it fails (Theano always works).
-python -c "import keras" &>/dev/null || {
-    test "true";
-    export KERAS_BACKEND="tensorflow"
-    python -c "import keras" &>/dev/null
-}
+KERAS_BACKEND="tensorflow"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - tensorflow     # [not (win and py27)]
     - pyyaml
     - six >=1.9.0
-    - theano
     - keras-applications >=1.0.6
     - keras-preprocessing >=1.0.5
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 46f8e5bd66f778abd8d5a62b3c3d749fbd41854176fcf0df5258cf94c3fd1b28
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
Theano needs a compiler, which breaks keras (and anyone depending on it) for anyone who doesn't have one. As Keras doesn't need a compiler and can use the tensorflow backend instead, this change makes keras more widely available; anyone who actually wants theano can handle its prereqs and install it.
 
See also:
conda-forge/theano-feedstock#28

(this change is potentially disruptive, and if any better solution comes to mind it'd be nice to find it)