### PR TITLE
Remove tensorflow and theano dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [win and vc<14]
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,8 @@ requirements:
     - h5py
     - numpy >=1.9.1
     - scipy >=0.14
-    - tensorflow     # [not (win and py27)]
     - pyyaml
     - six >=1.9.0
-    - theano
     - keras-applications >=1.0.8
     - keras-preprocessing >=1.1.0
 


### PR DESCRIPTION
By having `tensorflow` and `theano` as dependencies, the dependency tree of this package becomes very complex, which leads to dependency conflicts in some environments. The PyPI keras package doesn't depend on any backend.

---

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.